### PR TITLE
Fix the problem when the tag behavior is set dynamically and support custom tags

### DIFF
--- a/constant.go
+++ b/constant.go
@@ -1,7 +1,7 @@
 package mapper
 
 const (
-	packageVersion = "0.7.10"
+	packageVersion = "0.7.11"
 	mapperTagKey   = "mapper"
 	jsonTagKey     = "json"
 	IgnoreTagValue = "-"

--- a/example/main.go
+++ b/example/main.go
@@ -31,6 +31,11 @@ type (
 		Level string
 	}
 
+	Leader struct {
+		Name      string
+		LeaderAge int `form:"Age"`
+	}
+
 	JsonUser struct {
 		Name string
 		Age  int
@@ -39,8 +44,6 @@ type (
 )
 
 func init() {
-	mapper.Register(&User{})
-	mapper.Register(&Student{})
 }
 
 func main() {
@@ -73,6 +76,16 @@ func main() {
 		Age:  1,
 		Time: mapper.JSONTime(time.Now()),
 	}
+
+	user2 := &User{Name: "User2", Age: 35}
+	leader1 := &Leader{}
+	leader2 := &Leader{}
+	mapper.Mapper(user2, leader1)
+	fmt.Println("leader first:", leader1)
+	mapper.SetCustomTagName("form")
+	mapper.SetEnabledCustomTag(true)
+	mapper.Mapper(user2, leader2)
+	fmt.Println("leader second:", leader2)
 
 	fmt.Println(jsonUser)
 }

--- a/mapper.go
+++ b/mapper.go
@@ -37,6 +37,10 @@ type IMapper interface {
 	SetEnabledJsonTag(isEnabled bool)
 	IsEnabledJsonTag() bool
 
+	SetEnabledCustomTag(isEnabled bool)
+	IsEnabledCustomTag() bool
+	SetCustomTagName(tagName string)
+
 	SetEnabledAutoTypeConvert(isEnabled bool)
 	IsEnabledAutoTypeConvert() bool
 
@@ -84,6 +88,22 @@ func SetEnabledMapperTag(isEnabled bool) {
 // default is true
 func SetEnabledJsonTag(isEnabled bool) {
 	standardMapper.SetEnabledJsonTag(isEnabled)
+}
+
+// SetEnabledCustomTag set enabled flag for set custom tag name
+// if set true and set customTagName, the custom tag will be check during mapping's GetFieldName
+// default is false
+func SetEnabledCustomTag(isEnabled bool) {
+	standardMapper.SetEnabledCustomTag(isEnabled)
+}
+
+func IsEnabledCustomTag() bool {
+	return standardMapper.IsEnabledCustomTag()
+}
+
+// SetCustomTagName
+func SetCustomTagName(tagName string) {
+	standardMapper.SetCustomTagName(tagName)
 }
 
 // SetEnabledAutoTypeConvert set enabled flag for auto type convert

--- a/mapper_object.go
+++ b/mapper_object.go
@@ -22,6 +22,9 @@ type mapperObject struct {
 	enabledMapperTag         bool
 	enabledJsonTag           bool
 
+	enabledCustomTag bool
+	customTagName    string
+
 	// in the version < 0.7.8, we use field name as the key when mapping structs if field tag is "-"
 	// from 0.7.8, we add switch enableIgnoreFieldTag which is false in default
 	// if caller enable this flag, the field will be ignored in the mapping process
@@ -40,6 +43,7 @@ func NewMapper() IMapper {
 		enabledAutoTypeConvert:   true,
 		enabledMapperTag:         true,
 		enabledJsonTag:           true,
+		enabledCustomTag:         false,
 		enableFieldIgnoreTag:     false, // 保留老版本默认行为：对于tag = “-”的字段使用FieldName
 	}
 	dm.useWrapper(dm.DefaultTimeWrapper)
@@ -130,6 +134,7 @@ func (dm *mapperObject) IsEnabledTypeChecking() bool {
 // default is true
 func (dm *mapperObject) SetEnabledMapperTag(isEnabled bool) {
 	dm.enabledMapperTag = isEnabled
+	dm.cleanRegisterValue()
 }
 
 func (dm *mapperObject) IsEnabledMapperTag() bool {
@@ -141,6 +146,7 @@ func (dm *mapperObject) IsEnabledMapperTag() bool {
 // default is true
 func (dm *mapperObject) SetEnabledJsonTag(isEnabled bool) {
 	dm.enabledJsonTag = isEnabled
+	dm.cleanRegisterValue()
 }
 
 func (dm *mapperObject) IsEnabledJsonTag() bool {
@@ -170,6 +176,23 @@ func (dm *mapperObject) SetEnabledMapperStructField(isEnabled bool) {
 
 func (dm *mapperObject) IsEnabledMapperStructField() bool {
 	return dm.enabledMapperStructField
+}
+
+// SetEnabledCustomTag set enabled flag for set custom tag name
+// if set true and set customTagName, the custom tag will be check during mapping's GetFieldName
+// default is false
+func (dm *mapperObject) SetEnabledCustomTag(isEnabled bool) {
+	dm.enabledCustomTag = isEnabled
+	dm.cleanRegisterValue()
+}
+
+func (dm *mapperObject) IsEnabledCustomTag() bool {
+	return dm.enabledCustomTag
+}
+
+// SetCustomTagName
+func (dm *mapperObject) SetCustomTagName(tagName string) {
+	dm.customTagName = tagName
 }
 
 // SetEnableFieldIgnoreTag set the enabled flag for the ignored tag

--- a/mapper_object_internal.go
+++ b/mapper_object_internal.go
@@ -37,13 +37,20 @@ func (dm *mapperObject) registerValue(objValue reflect.Value) error {
 	return nil
 }
 
+// cleanRegisterValue clean all register Value
+func (dm *mapperObject) cleanRegisterValue() {
+	dm.registerMap.Range(func(key, value interface{}) bool {
+		dm.registerMap.Delete(key)
+		return true
+	})
+}
+
 // GetFieldName get fieldName with ElemValue and index
 // if config tag string, return tag value
 func (dm *mapperObject) getFieldName(objElem reflect.Value, index int) string {
 	fieldName := ""
 	field := objElem.Type().Field(index)
 	tag := dm.getStructTag(field)
-
 	// keeps the behavior in old version
 	if tag == IgnoreTagValue && !dm.IsEnableFieldIgnoreTag() {
 		tag = ""
@@ -285,6 +292,15 @@ func (dm *mapperObject) getStructTag(field reflect.StructField) string {
 		if tagValue != "" {
 			// support more tag property, as json tag omitempty 2018-07-13
 			return strings.Split(tagValue, ",")[0]
+		}
+	}
+
+	// 3.che
+	// ck customTag
+	if dm.enabledCustomTag {
+		tagValue = field.Tag.Get(dm.customTagName)
+		if tagValue != "" {
+			return tagValue
 		}
 	}
 

--- a/version.md
+++ b/version.md
@@ -1,5 +1,16 @@
 ## devfeel/mapper
 
+#### Version 0.7.11
+* BugFix: Fix the problem that getFieldName cannot take effect when the tag behavior is set dynamically.
+* Feature: Add SetEnabledCustomTag\SetCustomTagName to support custom tags, except mapper tag and json tag, for issue #34 
+* Tips: EnabledCustomTag default value is false.
+* you can use like this:
+``` go
+    mapper.SetCustomTagName("form")
+ 	mapper.SetEnabledCustomTag(true)
+```
+* 2022-07-04 18:00 in ShangHai
+
 #### Version 0.7.10
 * BugFix: remove go mod file.
 * 2022-04-20 20:00 in ShangHai


### PR DESCRIPTION
* BugFix: Fix the problem that getFieldName cannot take effect when the tag behavior is set dynamically.
* Feature: Add SetEnabledCustomTag\SetCustomTagName to support custom tags, except mapper tag and json tag, for issue #34
* Tips: EnabledCustomTag default value is false.
* you can use like this:
``` go
    mapper.SetCustomTagName("form")
 	mapper.SetEnabledCustomTag(true)
```
* 2022-07-04 18:00 in ShangHai