### PR TITLE
Rewrite mapperObject.Getfieldname & mapperObject.cleanRegisterValue

### DIFF
--- a/constant.go
+++ b/constant.go
@@ -1,7 +1,7 @@
 package mapper
 
 const (
-	packageVersion = "0.7.11"
+	packageVersion = "0.7.12"
 	mapperTagKey   = "mapper"
 	jsonTagKey     = "json"
 	IgnoreTagValue = "-"

--- a/example/main.go
+++ b/example/main.go
@@ -9,7 +9,7 @@ import (
 type (
 	User struct {
 		Name     string
-		Age      int
+		Age      int    `mapper:"_Age"`
 		Id       string `mapper:"_id"`
 		AA       string `json:"Score,omitempty"`
 		Data     []byte
@@ -33,7 +33,7 @@ type (
 
 	Leader struct {
 		Name      string
-		LeaderAge int `form:"Age"`
+		LeaderAge int `mapper:"_Age" form:"Age"`
 	}
 
 	JsonUser struct {
@@ -77,15 +77,26 @@ func main() {
 		Time: mapper.JSONTime(time.Now()),
 	}
 
-	user2 := &User{Name: "User2", Age: 35}
-	leader1 := &Leader{}
-	leader2 := &Leader{}
-	mapper.Mapper(user2, leader1)
-	fmt.Println("leader first:", leader1)
+	user = &User{Name: "User2", Age: 35}
+	leader := &Leader{}
+	mapper.Mapper(user, leader)
+	fmt.Println("leader first:", leader)
 	mapper.SetCustomTagName("form")
 	mapper.SetEnabledCustomTag(true)
-	mapper.Mapper(user2, leader2)
-	fmt.Println("leader second:", leader2)
+	leader = &Leader{}
+	mapper.Mapper(user, leader)
+	fmt.Println("leader second:", leader)
+
+	mapper.SetEnabledMapperTag(false)
+	leader = &Leader{}
+	mapper.Mapper(user, leader)
+	fmt.Println("leader third:", leader)
+
+	//mapper.SetEnabledMapperTag(false)
+	mapper.SetEnabledCustomTag(false)
+	leader = &Leader{}
+	mapper.Mapper(user, leader)
+	fmt.Println("leader fourth 2:", leader)
 
 	fmt.Println(jsonUser)
 }

--- a/mapper_object.go
+++ b/mapper_object.go
@@ -216,15 +216,7 @@ func (dm *mapperObject) GetTypeName(obj interface{}) string {
 // GetFieldName get fieldName with ElemValue and index
 // if config tag string, return tag value
 func (dm *mapperObject) GetFieldName(objElem reflect.Value, index int) string {
-	fieldName := ""
-	field := objElem.Type().Field(index)
-	tag := dm.getStructTag(field)
-	if tag != "" {
-		fieldName = tag
-	} else {
-		fieldName = field.Name
-	}
-	return fieldName
+	return dm.getFieldName(objElem, index)
 }
 
 func (dm *mapperObject) GetDefaultTimeWrapper() *TimeWrapper {

--- a/mapper_object_internal.go
+++ b/mapper_object_internal.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -37,12 +38,10 @@ func (dm *mapperObject) registerValue(objValue reflect.Value) error {
 	return nil
 }
 
-// cleanRegisterValue clean all register Value
+// cleanRegisterValue clean all register Value & field name map
 func (dm *mapperObject) cleanRegisterValue() {
-	dm.registerMap.Range(func(key, value interface{}) bool {
-		dm.registerMap.Delete(key)
-		return true
-	})
+	dm.registerMap = *new(sync.Map)
+	dm.fieldNameMap = *new(sync.Map)
 }
 
 // GetFieldName get fieldName with ElemValue and index

--- a/version.md
+++ b/version.md
@@ -1,5 +1,11 @@
 ## devfeel/mapper
 
+#### Version 0.7.12
+* Refactor: Solve the problem of repeated function implementation, rewrite "mapperObject.Getfieldname" direct call "mapperObject.getFieldName".
+* Refactor: Rewrite mapperObject.cleanRegisterValue, it will be reset registerMap & fieldNameMap.
+* 2022-07-06 14:00 in ShangHai
+
+
 #### Version 0.7.11
 * BugFix: Fix the problem that getFieldName cannot take effect when the tag behavior is set dynamically.
 * Feature: Add SetEnabledCustomTag\SetCustomTagName to support custom tags, except mapper tag and json tag, for issue #34 


### PR DESCRIPTION
* Refactor: Solve the problem of repeated function implementation, rewrite "mapperObject.Getfieldname" direct call "mapperObject.getFieldName".
* Refactor: Rewrite mapperObject.cleanRegisterValue, it will be reset registerMap & fieldNameMap.
* 2022-07-06 14:00 in ShangHai