### PR TITLE
#### Version 0.7.14

### DIFF
--- a/constant.go
+++ b/constant.go
@@ -1,7 +1,7 @@
 package mapper
 
 const (
-	packageVersion         = "0.7.13"
+	packageVersion         = "0.7.14"
 	mapperTagKey           = "mapper"
 	jsonTagKey             = "json"
 	IgnoreTagValue         = "-"

--- a/example/newmapper/main.go
+++ b/example/newmapper/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"github.com/devfeel/mapper"
+	"time"
+)
+
+type (
+	User struct {
+		Name     string
+		Age      int    `mapper:"_Age"`
+		Id       string `mapper:"_id"`
+		AA       string `json:"Score,omitempty"`
+		Data     []byte
+		Students []Student
+		Time     time.Time
+	}
+
+	Student struct {
+		Name  string
+		Age   int
+		Id    string `mapper:"_id"`
+		Score string
+	}
+
+	Teacher struct {
+		Name  string
+		Age   int
+		Id    string `mapper:"_id"`
+		Level string
+	}
+)
+
+func main() {
+	user := &User{}
+	userMap := &User{}
+	teacher := &Teacher{}
+	student := &Student{Name: "test", Age: 10, Id: "testId", Score: "100"}
+	valMap := make(map[string]interface{})
+	valMap["Name"] = "map"
+	valMap["Age"] = 10
+	valMap["_id"] = "x1asd"
+	valMap["Score"] = 100
+	valMap["Data"] = []byte{1, 2, 3, 4}
+	valMap["Students"] = []byte{1, 2, 3, 4} //[]Student{*student}
+	valMap["Time"] = time.Now()
+
+	mp := mapper.NewMapper(mapper.CTypeChecking(true), mapper.CMapperTag(true))
+
+	mp.Mapper(student, user)
+	mp.AutoMapper(student, teacher)
+	mp.MapperMap(valMap, userMap)
+
+	fmt.Println("student:", student)
+	fmt.Println("user:", user)
+	fmt.Println("teacher", teacher)
+	fmt.Println("userMap:", userMap)
+}

--- a/mapper.go
+++ b/mapper.go
@@ -23,6 +23,7 @@ type IMapper interface {
 
 	GetTypeName(obj interface{}) string
 	GetFieldName(objElem reflect.Value, index int) string
+	GetCustomTagName() string
 	GetDefaultTimeWrapper() *TimeWrapper
 
 	CheckExistsField(elem reflect.Value, fieldName string) (realFieldName string, exists bool)

--- a/mapper_object_internal.go
+++ b/mapper_object_internal.go
@@ -135,13 +135,13 @@ func (dm *mapperObject) convertstructfieldInternal(fieldName string, fromFieldIn
 
 	toFieldInfo := toElem.FieldByName(realFieldName)
 	// check field is same type
-	if dm.enabledTypeChecking {
+	if dm.setting.EnabledTypeChecking {
 		if fromFieldInfo.Kind() != toFieldInfo.Kind() {
 			return nil
 		}
 	}
 
-	if dm.enabledMapperStructField &&
+	if dm.setting.EnabledMapperStructField &&
 		toFieldInfo.Kind() == reflect.Struct && fromFieldInfo.Kind() == reflect.Struct &&
 		toFieldInfo.Type() != fromFieldInfo.Type() &&
 		!dm.checkIsTypeWrapper(toFieldInfo) && !dm.checkIsTypeWrapper(fromFieldInfo) {
@@ -154,7 +154,7 @@ func (dm *mapperObject) convertstructfieldInternal(fieldName string, fromFieldIn
 		}
 	} else {
 		isSet := false
-		if dm.enabledAutoTypeConvert {
+		if dm.setting.EnabledAutoTypeConvert {
 			if dm.DefaultTimeWrapper.IsType(fromFieldInfo) && toFieldInfo.Kind() == reflect.Int64 {
 				fromTime := fromFieldInfo.Interface().(time.Time)
 				toFieldInfo.Set(reflect.ValueOf(TimeToUnix(fromTime)))
@@ -263,7 +263,7 @@ func (dm *mapperObject) setFieldValue(fieldValue reflect.Value, fieldKind reflec
 			case string:
 				timeString = d
 			case int64:
-				if dm.enabledAutoTypeConvert {
+				if dm.setting.EnabledAutoTypeConvert {
 					// try to transform Unix time to local Time
 					t, err := UnixToTimeLocation(value.(int64), time.UTC.String())
 					if err != nil {
@@ -303,7 +303,7 @@ func (dm *mapperObject) setFieldValue(fieldValue reflect.Value, fieldKind reflec
 func (dm *mapperObject) getStructTag(field reflect.StructField) string {
 	tagValue := ""
 	// 1.check mapperTagKey
-	if dm.enabledMapperTag {
+	if dm.setting.EnabledMapperTag {
 		tagValue = field.Tag.Get(mapperTagKey)
 		if tagValue != "" {
 			return tagValue
@@ -311,7 +311,7 @@ func (dm *mapperObject) getStructTag(field reflect.StructField) string {
 	}
 
 	// 2.check jsonTagKey
-	if dm.enabledJsonTag {
+	if dm.setting.EnabledJsonTag {
 		tagValue = field.Tag.Get(jsonTagKey)
 		if tagValue != "" {
 			// support more tag property, as json tag omitempty 2018-07-13
@@ -321,8 +321,8 @@ func (dm *mapperObject) getStructTag(field reflect.StructField) string {
 
 	// 3.che
 	// ck customTag
-	if dm.enabledCustomTag {
-		tagValue = field.Tag.Get(dm.customTagName)
+	if dm.setting.EnabledCustomTag {
+		tagValue = field.Tag.Get(dm.setting.CustomTagName)
 		if tagValue != "" {
 			return tagValue
 		}

--- a/mapper_object_test.go
+++ b/mapper_object_test.go
@@ -1,12 +1,18 @@
 package mapper
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 )
+
+func TestMapperObject_NewMapper(t *testing.T) {
+	m := NewMapper(CTypeChecking(true), CCustomTagName("^"))
+	fmt.Println(m)
+}
 
 func Test_Object_SetEnabledTypeChecking(t *testing.T) {
 	m := NewMapper()

--- a/mapper_setting.go
+++ b/mapper_setting.go
@@ -1,0 +1,104 @@
+package mapper
+
+// Option 用于设置 Config 结构体的字段。
+type Option func(*Setting)
+
+type Setting struct {
+	EnabledTypeChecking      bool
+	EnabledMapperStructField bool
+	EnabledAutoTypeConvert   bool
+	EnabledMapperTag         bool
+	EnabledJsonTag           bool
+	EnabledCustomTag         bool
+	CustomTagName            string
+
+	// in the version < 0.7.8, we use field name as the key when mapping structs if field tag is "-"
+	// from 0.7.8, we add switch enableIgnoreFieldTag which is false in default
+	// if caller enable this flag, the field will be ignored in the mapping process
+	EnableFieldIgnoreTag bool
+}
+
+// getDefaultSetting return default mapper setting
+// Use default value:
+//
+//	EnabledTypeChecking:      false,
+//	EnabledMapperStructField: true,
+//	EnabledAutoTypeConvert:   true,
+//	EnabledMapperTag:         true,
+//	EnabledJsonTag:           true,
+//	EnabledCustomTag:         false,
+//	EnableFieldIgnoreTag:     false
+func getDefaultSetting() *Setting {
+	return &Setting{
+		EnabledTypeChecking:      false,
+		EnabledMapperStructField: true,
+		EnabledAutoTypeConvert:   true,
+		EnabledMapperTag:         true,
+		EnabledJsonTag:           true,
+		EnabledCustomTag:         false,
+		EnableFieldIgnoreTag:     false, // 保留老版本默认行为：对于tag = “-”的字段使用FieldName
+	}
+}
+
+// NewSetting create new setting with multi option
+func NewSetting(opts ...Option) *Setting {
+	cfg := getDefaultSetting()
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
+// CTypeChecking set EnabledTypeChecking value
+//
+// Default value: false
+func CTypeChecking(isEnabled bool) Option {
+	return func(c *Setting) {
+		c.EnabledTypeChecking = isEnabled
+	}
+}
+
+// CMapperTag set EnabledMapperTag value
+//
+// Default value: true
+func CMapperTag(isEnabled bool) Option {
+	return func(c *Setting) {
+		c.EnabledMapperTag = isEnabled
+	}
+}
+
+func CJsonTag(isEnabled bool) Option {
+	return func(c *Setting) {
+		c.EnabledJsonTag = isEnabled
+	}
+}
+
+func CAutoTypeConvert(isEnabled bool) Option {
+	return func(c *Setting) {
+		c.EnabledAutoTypeConvert = isEnabled
+	}
+}
+
+func CMapperStructField(isEnabled bool) Option {
+	return func(c *Setting) {
+		c.EnabledMapperStructField = isEnabled
+	}
+}
+
+func CCustomTag(isEnabled bool) Option {
+	return func(c *Setting) {
+		c.EnabledCustomTag = isEnabled
+	}
+}
+
+func CFieldIgnoreTag(isEnabled bool) Option {
+	return func(c *Setting) {
+		c.EnableFieldIgnoreTag = isEnabled
+	}
+}
+
+func CCustomTagName(tagName string) Option {
+	return func(c *Setting) {
+		c.CustomTagName = tagName
+	}
+}

--- a/mapper_setting_test.go
+++ b/mapper_setting_test.go
@@ -1,0 +1,15 @@
+package mapper
+
+import "testing"
+
+func TestNewSetting(t *testing.T) {
+	checkEnabledTypeChecking := true
+	checkEnabledAutoTypeConvert := false
+
+	setting := NewSetting(CTypeChecking(checkEnabledTypeChecking), CAutoTypeConvert(checkEnabledAutoTypeConvert))
+	if setting.EnabledTypeChecking != checkEnabledTypeChecking || setting.EnabledAutoTypeConvert != checkEnabledAutoTypeConvert {
+		t.Error("NewSetting error: [", checkEnabledTypeChecking, ",", setting.EnabledTypeChecking, "],[", checkEnabledAutoTypeConvert, ",", setting.EnabledAutoTypeConvert, "]")
+	} else {
+		t.Log("NewSetting success")
+	}
+}

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -42,6 +42,15 @@ func init() {
 	testValue = reflect.ValueOf(&testStruct{})
 }
 
+func TestPackageVersion(t *testing.T) {
+	v := PackageVersion()
+	if v != packageVersion {
+		t.Error("PackageVersion error: not equal with packageVersion[" + packageVersion + "]")
+	} else {
+		t.Log("PackageVersion success")
+	}
+}
+
 func Test_CheckIsTypeWrapper(t *testing.T) {
 	v := TagStruct{}
 	if standardMapper.CheckIsTypeWrapper(reflect.ValueOf(v)) == true {

--- a/version.md
+++ b/version.md
@@ -1,5 +1,27 @@
 ## devfeel/mapper
 
+#### Version 0.7.14
+* Feature: Implement variable arguments based on NewMapper for flexible configuration settings when you init mapper.
+* Feature: Add Setting struct used to Config mapper
+* you can use like this:
+``` go
+  // Default Setting:
+  // EnabledTypeChecking:      false,
+  // EnabledMapperStructField: true,
+  // EnabledAutoTypeConvert:   true,
+  // EnabledMapperTag:         true,
+  // EnabledJsonTag:           true,
+  // EnabledCustomTag:         false,
+  // EnableFieldIgnoreTag:     false,
+  
+  /// When you use default setting
+  NewMapper()
+  
+  /// When you will change some setting
+  NewMapper(CTypeChecking(true), CCustomTagName("-"))
+```
+* 2024-09-06 19:00 in ShangHai
+
 #### Version 0.7.13
 * Feature: Added the "composite-field" tag to continue expanding and searching for corresponding field mappings when encountering composite fields in a Struct. Currently, only one level of expansion is supported.
 * Tips: Thanks to @naeemaei for issue #39


### PR DESCRIPTION
* Feature: Implement variable arguments based on NewMapper for flexible configuration settings when you init mapper.
* Feature: Add Setting struct used to Config mapper
* you can use like this:
``` go
  // Default Setting:
  // EnabledTypeChecking:      false,
  // EnabledMapperStructField: true,
  // EnabledAutoTypeConvert:   true,
  // EnabledMapperTag:         true,
  // EnabledJsonTag:           true,
  // EnabledCustomTag:         false,
  // EnableFieldIgnoreTag:     false,

  /// When you use default setting
  NewMapper()

  /// When you will change some setting
  NewMapper(CTypeChecking(true), CCustomTagName("-"))
```
* 2024-09-06 19:00 in ShangHai