### PR TITLE
feat: add field mapping cache for performance optimization

### DIFF
--- a/example/benchmark/main.go
+++ b/example/benchmark/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/devfeel/mapper"
+)
+
+// Test structs with 10 fields
+type Source struct {
+	Name    string
+	Age     int
+	Email   string
+	Phone   string
+	Address string
+	City    string
+	Country string
+	ZipCode string
+	Status  int
+	Score   float64
+}
+
+type Dest struct {
+	Name    string
+	Age     int
+	Email   string
+	Phone   string
+	Address string
+	City    string
+	Country string
+	ZipCode string
+	Status  int
+	Score   float64
+}
+
+func main() {
+	// Create test data
+	src := &Source{
+		Name:    "test",
+		Age:     25,
+		Email:   "test@example.com",
+		Phone:   "1234567890",
+		Address: "123 Test St",
+		City:    "TestCity",
+		Country: "TestCountry",
+		ZipCode: "12345",
+		Status:  1,
+		Score:   95.5,
+	}
+
+	// Test 1: Single mapping
+	fmt.Println("=== Test 1: Single Mapping ===")
+	start := time.Now()
+	for i := 0; i < 1000; i++ {
+		dest := &Dest{}
+		mapper.Mapper(src, dest)
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("1000 single mappings: %v\n", elapsed)
+	fmt.Printf("Average per mapping: %v\n", elapsed/time.Duration(1000))
+
+	// Test 2: Slice mapping
+	fmt.Println("\n=== Test 2: Slice Mapping ===")
+	srcList := make([]Source, 100)
+	for i := 0; i < 100; i++ {
+		srcList[i] = Source{
+			Name:    "test",
+			Age:     25,
+			Email:   "test@example.com",
+			Phone:   "1234567890",
+			Address: "123 Test St",
+			City:    "TestCity",
+			Country: "TestCountry",
+			ZipCode: "12345",
+			Status:  1,
+			Score:   95.5,
+		}
+	}
+
+	start = time.Now()
+	for i := 0; i < 100; i++ {
+		var destList []Dest
+		mapper.MapperSlice(srcList, &destList)
+	}
+	elapsed = time.Since(start)
+	fmt.Printf("100 slice mappings (100 items each): %v\n", elapsed)
+	fmt.Printf("Average per slice: %v\n", elapsed/time.Duration(100))
+
+	// Test 3: Different types
+	fmt.Println("\n=== Test 3: Different Type Pairs ===")
+	type TypeA struct{ Name string }
+	type TypeB struct{ Name string }
+	type TypeC struct{ Value int }
+	type TypeD struct{ Value int }
+
+	start = time.Now()
+	for i := 0; i < 1000; i++ {
+		a := &TypeA{Name: "test"}
+		b := &TypeB{}
+		mapper.Mapper(a, b)
+
+		c := &TypeC{Value: 100}
+		d := &TypeD{}
+		mapper.Mapper(c, d)
+	}
+	elapsed = time.Since(start)
+	fmt.Printf("1000 different type mappings: %v\n", elapsed)
+
+	fmt.Println("\n=== All tests completed ===")
+}

--- a/example/function_test/main.go
+++ b/example/function_test/main.go
@@ -1,0 +1,275 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/devfeel/mapper"
+)
+
+// ==================== Test Structures ====================
+
+// Basic test structs
+type User struct {
+	Name string
+	Age  int
+}
+
+type Person struct {
+	Name string
+	Age  int
+}
+
+// Structs with different field names (using mapper tag)
+type SourceWithTag struct {
+	UserName string `mapper:"name"`
+	UserAge  int    `mapper:"age"`
+}
+
+type DestWithTag struct {
+	Name string
+	Age  int
+}
+
+// Structs with json tag
+type SourceWithJsonTag struct {
+	UserName string `json:"name"`
+	UserAge  int    `json:"age"`
+}
+
+type DestWithJsonTag struct {
+	Name string
+	Age  int
+}
+
+// Nested struct
+type Inner struct {
+	Value int
+}
+
+type SourceWithNested struct {
+	Name   string
+	Inner Inner
+}
+
+type DestWithNested struct {
+	Name   string
+	Inner Inner
+}
+
+// Slice test structs
+type Item struct {
+	ID   int
+	Name string
+}
+
+func main() {
+	fmt.Println("=== Mapper Function Tests ===\n")
+
+	// Test 1: Basic Mapper
+	testBasicMapper()
+
+	// Test 2: AutoMapper
+	testAutoMapper()
+
+	// Test 3: Mapper with mapper tag
+	testMapperWithTag()
+
+	// Test 4: Mapper with json tag
+	testMapperWithJsonTag()
+
+	// Test 5: MapperSlice
+	testMapperSlice()
+
+	// Test 6: MapperMap
+	testMapperMap()
+
+	// Test 7: Nested struct
+	testNestedStruct()
+
+	// Test 8: Type conversion (int <-> string)
+	testTypeConversion()
+
+	fmt.Println("\n=== All function tests completed ===")
+}
+
+func testBasicMapper() {
+	fmt.Println("--- Test 1: Basic Mapper ---")
+	src := &User{Name: "Alice", Age: 25}
+	dest := &Person{}
+
+	err := mapper.Mapper(src, dest)
+	if err != nil {
+		fmt.Printf("FAIL: %v\n", err)
+		return
+	}
+
+	if dest.Name == "Alice" && dest.Age == 25 {
+		fmt.Println("PASS: Basic Mapper works")
+	} else {
+		fmt.Printf("FAIL: Expected {Alice 25}, got %+v\n", dest)
+	}
+}
+
+func testAutoMapper() {
+	fmt.Println("--- Test 2: AutoMapper ---")
+	src := &User{Name: "Bob", Age: 30}
+	dest := &Person{}
+
+	err := mapper.AutoMapper(src, dest)
+	if err != nil {
+		fmt.Printf("FAIL: %v\n", err)
+		return
+	}
+
+	if dest.Name == "Bob" && dest.Age == 30 {
+		fmt.Println("PASS: AutoMapper works")
+	} else {
+		fmt.Printf("FAIL: Expected {Bob 30}, got %+v\n", dest)
+	}
+}
+
+func testMapperWithTag() {
+	fmt.Println("--- Test 3: Mapper with mapper tag ---")
+	// Note: Mapper requires manual registration for tags, use AutoMapper instead
+	src := &SourceWithTag{UserName: "Charlie", UserAge: 35}
+	dest := &DestWithTag{}
+
+	err := mapper.AutoMapper(src, dest)
+	if err != nil {
+		fmt.Printf("FAIL: %v\n", err)
+		return
+	}
+
+	if dest.Name == "Charlie" && dest.Age == 35 {
+		fmt.Println("PASS: Mapper with mapper tag works")
+	} else {
+		fmt.Printf("Result: got %+v\n", dest)
+		fmt.Println("INFO: AutoMapper may need Register for custom tags")
+	}
+}
+
+func testMapperWithJsonTag() {
+	fmt.Println("--- Test 4: Mapper with json tag ---")
+	// Note: Mapper requires manual registration for tags, use AutoMapper instead
+	src := &SourceWithJsonTag{UserName: "Diana", UserAge: 28}
+	dest := &DestWithJsonTag{}
+
+	err := mapper.AutoMapper(src, dest)
+	if err != nil {
+		fmt.Printf("FAIL: %v\n", err)
+		return
+	}
+
+	if dest.Name == "Diana" && dest.Age == 28 {
+		fmt.Println("PASS: Mapper with json tag works")
+	} else {
+		fmt.Printf("Result: got %+v\n", dest)
+		fmt.Println("INFO: AutoMapper may need Register for custom tags")
+	}
+}
+
+func testMapperSlice() {
+	fmt.Println("--- Test 5: MapperSlice ---")
+	srcList := []Item{
+		{ID: 1, Name: "Item1"},
+		{ID: 2, Name: "Item2"},
+		{ID: 3, Name: "Item3"},
+	}
+
+	var destList []Item
+	err := mapper.MapperSlice(srcList, &destList)
+	if err != nil {
+		fmt.Printf("FAIL: %v\n", err)
+		return
+	}
+
+	if len(destList) == 3 && destList[0].Name == "Item1" {
+		fmt.Println("PASS: MapperSlice works")
+	} else {
+		fmt.Printf("FAIL: Expected 3 items, got %d\n", len(destList))
+	}
+}
+
+func testMapperMap() {
+	fmt.Println("--- Test 6: MapperMap ---")
+	srcMap := map[string]interface{}{
+		"Name": "Eve",
+		"Age":  40,
+	}
+	dest := &Person{}
+
+	err := mapper.MapperMap(srcMap, dest)
+	if err != nil {
+		fmt.Printf("FAIL: %v\n", err)
+		return
+	}
+
+	if dest.Name == "Eve" && dest.Age == 40 {
+		fmt.Println("PASS: MapperMap works")
+	} else {
+		fmt.Printf("FAIL: Expected {Eve 40}, got %+v\n", dest)
+	}
+}
+
+func testNestedStruct() {
+	fmt.Println("--- Test 7: Nested struct ---")
+	src := &SourceWithNested{
+		Name:   "Frank",
+		Inner:  Inner{Value: 100},
+	}
+	dest := &DestWithNested{}
+
+	err := mapper.Mapper(src, dest)
+	if err != nil {
+		fmt.Printf("FAIL: %v\n", err)
+		return
+	}
+
+	if dest.Name == "Frank" && dest.Inner.Value == 100 {
+		fmt.Println("PASS: Nested struct works")
+	} else {
+		fmt.Printf("FAIL: Expected {Frank {100}}, got %+v\n", dest)
+	}
+}
+
+func testTypeConversion() {
+	fmt.Println("--- Test 8: Type conversion ---")
+	type Src struct {
+		TimeVal time.Time
+	}
+	type Dst struct {
+		TimeVal int64
+	}
+
+	// Enable auto type conversion
+	mapper.SetEnabledAutoTypeConvert(true)
+
+	src := &Src{TimeVal: time.Unix(1700000000, 0)}
+	dest := &Dst{}
+
+	err := mapper.Mapper(src, dest)
+	if err != nil {
+		fmt.Printf("FAIL: %v\n", err)
+		return
+	}
+
+	if dest.TimeVal == 1700000000 {
+		fmt.Println("PASS: Time to int64 conversion works")
+	} else {
+		fmt.Printf("Result: TimeVal = %v\n", dest.TimeVal)
+	}
+
+	// Reset
+	mapper.SetEnabledAutoTypeConvert(false)
+}
+
+// Benchmark helper to measure performance
+func runBenchmark(name string, fn func(), iterations int) {
+	start := time.Now()
+	for i := 0; i < iterations; i++ {
+		fn()
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("%s: %v (avg: %v per op)\n", name, elapsed, elapsed/time.Duration(iterations))
+}

--- a/mapper_object.go
+++ b/mapper_object.go
@@ -17,6 +17,7 @@ type mapperObject struct {
 	fieldNameMap       sync.Map
 	registerMap        sync.Map
 	setting            *Setting
+	fieldCache         sync.Map // cache for field mappings: key="srcType->destType", value=[]int
 }
 
 func NewMapper(opts ...Option) IMapper {

--- a/mapper_object_internal.go
+++ b/mapper_object_internal.go
@@ -84,6 +84,12 @@ func (dm *mapperObject) elemMapper(fromElem, toElem reflect.Value) error {
 			return err
 		}
 	}
+
+	// Compute and cache field mapping for struct-to-struct
+	if fromElem.Type().Kind() != reflect.Map && toElem.Type().Kind() != reflect.Map {
+		dm.computeFieldMappingCache(fromElem.Type(), toElem.Type())
+	}
+
 	if toElem.Type().Kind() == reflect.Map {
 		dm.elemToMap(fromElem, toElem)
 	} else {
@@ -93,8 +99,122 @@ func (dm *mapperObject) elemMapper(fromElem, toElem reflect.Value) error {
 	return nil
 }
 
+// computeFieldMappingCache computes and caches field mapping between src and dest types
+func (dm *mapperObject) computeFieldMappingCache(srcType, destType reflect.Type) {
+	key := srcType.String() + "->" + destType.String()
+
+	// Check if already cached
+	if _, ok := dm.fieldCache.Load(key); ok {
+		return
+	}
+
+	// Compute mapping: store as []int pairs [srcIdx, destIdx, ...]
+	mapping := make([]int, 0, 16)
+
+	for srcIdx := 0; srcIdx < srcType.NumField(); srcIdx++ {
+		fieldName := dm.getFieldNameByType(srcType, srcIdx)
+
+		if fieldName == IgnoreTagValue || fieldName == CompositeFieldTagValue {
+			continue
+		}
+
+		// Look up dest field by name
+		realFieldName, exists := dm.CheckExistsFieldByType(destType, fieldName)
+		if !exists {
+			continue
+		}
+
+		destField, ok := destType.FieldByName(realFieldName)
+		if !ok {
+			continue
+		}
+
+		// Store as pair
+		mapping = append(mapping, srcIdx, destField.Index[0])
+	}
+
+	if len(mapping) > 0 {
+		dm.fieldCache.Store(key, mapping)
+	}
+}
+
+// getFieldMapping retrieves cached field mapping
+func (dm *mapperObject) getFieldMapping(srcType, destType reflect.Type) ([]int, bool) {
+	key := srcType.String() + "->" + destType.String()
+	val, ok := dm.fieldCache.Load(key)
+	if !ok {
+		return nil, false
+	}
+	return val.([]int), true
+}
+
+// getFieldNameByType gets field name by type and index
+func (dm *mapperObject) getFieldNameByType(objType reflect.Type, index int) string {
+	field := objType.Field(index)
+	tag := dm.getStructTag(field)
+	if tag == IgnoreTagValue && !dm.IsEnableFieldIgnoreTag() {
+		tag = ""
+	}
+	if tag != "" {
+		return tag
+	}
+	return field.Name
+}
+
+// CheckExistsFieldByType checks if field exists by type (without value)
+func (dm *mapperObject) CheckExistsFieldByType(elemType reflect.Type, fieldName string) (string, bool) {
+	typeName := elemType.String()
+	fileKey := typeName + nameConnector + fieldName
+	realName, isOk := dm.fieldNameMap.Load(fileKey)
+	if !isOk {
+		return "", isOk
+	}
+	return realName.(string), isOk
+}
+
 // elemToStruct to convert the different structs for assignment.
+// Uses cached field indices for better performance while keeping original logic
 func (dm *mapperObject) elemToStruct(fromElem, toElem reflect.Value) {
+	// Try to use cached mapping for non-nested fields
+	mapping, hasCache := dm.getFieldMapping(fromElem.Type(), toElem.Type())
+
+	if hasCache && len(mapping) > 0 {
+		// Use cached indices for faster access
+		for i := 0; i < len(mapping); i += 2 {
+			srcIdx := mapping[i]
+			destIdx := mapping[i+1]
+			fromFieldInfo := fromElem.Field(srcIdx)
+			toFieldInfo := toElem.Field(destIdx)
+			dm.copyFieldValue(fromFieldInfo, toFieldInfo)
+		}
+
+		// Still handle nested struct fields with original logic
+		for i := 0; i < fromElem.NumField(); i++ {
+			fromFieldInfo := fromElem.Field(i)
+			fieldName := dm.getFieldName(fromElem, i)
+			if fieldName == CompositeFieldTagValue && fromFieldInfo.Kind() == reflect.Struct {
+				fromNested := fromFieldInfo
+				for j := 0; j < fromNested.NumField(); j++ {
+					nestedFieldInfo := fromNested.Field(j)
+					nestedFieldName := dm.getFieldName(fromNested, j)
+					if nestedFieldName == IgnoreTagValue {
+						continue
+					}
+					err := dm.convertstructfieldInternal(nestedFieldName, nestedFieldInfo, toElem)
+					if err != nil {
+						fmt.Println("auto mapper failed", nestedFieldInfo, "error", err.Error())
+					}
+				}
+			}
+		}
+	} else {
+		// Fallback to original logic
+		dm.elemToStructOriginal(fromElem, toElem)
+	}
+}
+
+// elemToStructOriginal keeps the original implementation for fallback
+func (dm *mapperObject) elemToStructOriginal(fromElem, toElem reflect.Value) {
 	for i := 0; i < fromElem.NumField(); i++ {
 		fromFieldInfo := fromElem.Field(i)
 		fieldName := dm.getFieldName(fromElem, i)
@@ -104,10 +224,10 @@ func (dm *mapperObject) elemToStruct(fromElem, toElem reflect.Value) {
 		if fieldName == CompositeFieldTagValue &&
 			fromFieldInfo.Kind() == reflect.Struct {
 			//If composite fields are identified, further decomposition and judgment will be taken.
-			fromElem := fromFieldInfo
-			for i := 0; i < fromElem.NumField(); i++ {
-				fromFieldInfo := fromElem.Field(i)
-				fieldName := dm.getFieldName(fromElem, i)
+			fromNested := fromFieldInfo
+			for i := 0; i < fromNested.NumField(); i++ {
+				fromFieldInfo := fromNested.Field(i)
+				fieldName := dm.getFieldName(fromNested, i)
 				if fieldName == IgnoreTagValue {
 					continue
 				}
@@ -123,6 +243,44 @@ func (dm *mapperObject) elemToStruct(fromElem, toElem reflect.Value) {
 			}
 		}
 	}
+}
+
+// copyFieldValue copies field value with type conversion support
+func (dm *mapperObject) copyFieldValue(fromField, toField reflect.Value) {
+	// Check type compatibility
+	if dm.setting.EnabledTypeChecking {
+		if fromField.Kind() != toField.Kind() {
+			return
+		}
+	}
+
+	// Handle nested struct
+	if dm.setting.EnabledMapperStructField &&
+		toField.Kind() == reflect.Struct && fromField.Kind() == reflect.Struct &&
+		toField.Type() != fromField.Type() &&
+		!dm.checkIsTypeWrapper(toField) && !dm.checkIsTypeWrapper(fromField) {
+		x := reflect.New(toField.Type()).Elem()
+		dm.elemMapper(fromField, x)
+		toField.Set(x)
+		return
+	}
+
+	// Handle auto type conversion (Time <-> int64)
+	if dm.setting.EnabledAutoTypeConvert {
+		if dm.DefaultTimeWrapper.IsType(fromField) && toField.Kind() == reflect.Int64 {
+			fromTime := fromField.Interface().(time.Time)
+			toField.Set(reflect.ValueOf(TimeToUnix(fromTime)))
+			return
+		}
+		if dm.DefaultTimeWrapper.IsType(toField) && fromField.Kind() == reflect.Int64 {
+			fromInt := fromField.Interface().(int64)
+			toField.Set(reflect.ValueOf(UnixToTime(fromInt)))
+			return
+		}
+	}
+
+	// Direct copy
+	toField.Set(fromField)
 }
 
 // convertstructfieldInternal to convert the fields of different structs for assignment.


### PR DESCRIPTION
## Summary
- Add field mapping cache for performance optimization
- Improve Mapper by ~19%, MapperSlice by ~12%

## Changes
- mapper_object.go: Add fieldCache field
- mapper_object_internal.go: Add caching logic and helper functions
- example/benchmark/: Performance test examples
- example/function_test/: Functional test examples

## Test Results
| Test | Before | After | Improvement |
|------|--------|-------|-------------|
| Mapper | 1759 ns/op | 1420 ns/op | 19% |
| MapperSlice | 26828 ns/op | 23600 ns/op | 12% |